### PR TITLE
Shared client

### DIFF
--- a/bees/views.py
+++ b/bees/views.py
@@ -4,14 +4,15 @@ from django.conf import settings
 from kazoo.client import KazooClient
 from bees.forms import CreateNodeForm, EditNodeForm, DeleteNodeForm
 
+ZK_CLIENT = KazooClient(hosts=settings.ZOOKEEPER_HOSTS)
+ZK_CLIENT.start()
 
 class ZookeeperClientMixin(object):
     @property
     def zk_client(self):
         if hasattr(self, "_zk_client"):
             return self._zk_client
-        self._zk_client = KazooClient(hosts=settings.ZOOKEEPER_HOSTS)
-        self._zk_client.start()
+        self._zk_client = ZK_CLIENT
         return self._zk_client
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django==1.6.5
 django-bootstrap3==4.6.0
 django-extensions==1.3.7
-kazoo==1.3.1
+kazoo==2.2.1


### PR DESCRIPTION
This PR upgrades kazoo to latest (2.2.1) and initializes a shared instance of KazooClient at startup to avoid unnecessary overhead on each request while establishing a new session to ZooKeeper.

Also fixes resource leak where clients are not closed when the request has completed, resulting in the app needing to be restarted.
